### PR TITLE
libhello 0.1.1103+selftest_by_alr_publish_action

### DIFF
--- a/index/li/libhello/libhello-0.1.1103+selftest_by_alr_publish_action.toml
+++ b/index/li/libhello/libhello-0.1.1103+selftest_by_alr_publish_action.toml
@@ -1,0 +1,15 @@
+name = "libhello"
+description = "Basic library demonstration project"
+version = "0.1.1103+selftest_by_alr_publish_action"
+tags = ["hello", "demo", "library"]
+licenses = "MIT"
+website = "https://github.com/alire-project/libhello"
+
+authors = ["Alejandro R. Mosteo"]
+maintainers = ["Alejandro R. Mosteo <alejandro@mosteo.com>"]
+maintainers-logins = ["mosteo"]
+
+[origin]
+commit = "dd729e8919aa9507256d7cf384d9debf8bcdc605"
+url = "git+file:/home/runner/work/alr-publish/alr-publish/libhello.upstream"
+


### PR DESCRIPTION
Created via `alr publish` with `alr 2.1.0`